### PR TITLE
adds 4 GET articles-by-article-id

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -14,6 +14,18 @@ afterAll(() => {
 })
 
 
+describe('/GET incorrect path', () => {
+    test('Responds with 404 if incorrect path specified', () => {
+        return request(app)
+        .get('/api/notTopics')
+        .expect(404)
+        .then(({ body }) => {
+          expect(body.msg).toBe("not found")
+        })  
+      })
+});
+
+
 describe('GET/api/topics', () => {
     test('Responds with 200 code & with array of topics, each with: slug, description ', () => {
         return request(app)
@@ -30,20 +42,9 @@ describe('GET/api/topics', () => {
       })     
 });
 
-describe('/GET incorrect path', () => {
-    test('Responds with 404 if incorrect path specified', () => {
-        return request(app)
-        .get('/api/notTopics')
-        .expect(404)
-        .then(({ body }) => {
-          expect(body.msg).toBe("not found")
-        })  
-      })
-});
-
 
 describe('/GET api', () => {
-    test('Responds information on available api endpoints', () => {
+    test('Responds with information on available api endpoints', () => {
         return request(app)
         .get('/api')
         .expect(200)
@@ -51,4 +52,55 @@ describe('/GET api', () => {
           expect(body).toEqual(endpoints)
         })  
       })
+});
+
+
+describe('/GET api/articles:article_id', () => {
+
+    test('Responds with the correct article for the given article_id', () => {
+        let article = {
+            article_id: 1,
+            title: 'Living in the shadow of a great man',
+            topic: 'mitch',
+            author: 'butter_bridge',
+            body: 'I find this existence challenging',
+            created_at: '2020-07-09T20:11:00.000Z',
+            votes: 100,
+            article_img_url: 'https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700'
+          }
+        return request(app)
+        .get('/api/articles/1')
+        .expect(200)
+        .then(({ body }) => {  
+        expect(body).toEqual(article)
+        expect(typeof body.author).toBe("string");
+        expect(typeof body.title).toBe("string");
+        expect(typeof body.article_id).toBe("number");
+        expect(typeof body.body).toBe("string");
+        expect(typeof body.topic).toBe("string");
+        expect(typeof body.created_at).toBe("string");
+        expect(typeof body.votes).toBe("number");
+        expect(typeof body.article_img_url).toBe("string");
+        })  
+      })
+
+
+    test('Responds with 404 Not found for an article_id not found in the dataset', () => {
+        return request(app)
+        .get('/api/articles/999999')
+        .expect(404)
+        .then(({ body }) => {  
+            expect(body.msg).toBe("couldn't find requested article")
+        })  
+    });
+
+
+    test('Resonds with 400 bad request for an invalid article_id', () => {
+        return request(app)
+        .get('/api/articles/not-an-id-number')
+        .expect(400)
+        .then(({ body }) => {  
+            expect(body.msg).toBe("Bad request")
+        })  
+    });
 });

--- a/app.js
+++ b/app.js
@@ -2,7 +2,7 @@ const express = require("express")
 const app = express()
 const {getTopics} = require("./controllers/topics.controllers")
 const {getApi} = require("./controllers/api.controllers")
-
+const {getArticleById} = require("./controllers/articles.controllers")
 
 
 app.use(express.json())
@@ -10,6 +10,8 @@ app.use(express.json())
 app.get('/api/topics', getTopics)
 
 app.get('/api', getApi)
+
+app.get('/api/articles/:article_id', getArticleById)
 
 
 //Error handling:

--- a/controllers/articles.controllers.js
+++ b/controllers/articles.controllers.js
@@ -1,0 +1,14 @@
+const app = require("../app")
+const {fetchArticleById} = require("../models/articles.models")
+
+function getArticleById(req,res,next){
+
+    const id = req.params
+    fetchArticleById(id)
+    .then((article) => {
+        res.status(200).send(article)
+    })
+    .catch(next)
+}   
+
+module.exports={getArticleById}

--- a/endpoints.json
+++ b/endpoints.json
@@ -25,5 +25,19 @@
         }
       ]
     }
+  },
+  "GET /api/articles/:article_id": {
+    "description": "retrieves a single article",
+    "queries": [],
+    "exampleResponse": {
+      "article": {"title": "Living in the shadow of a great man",
+      "topic": "mitch",
+      "author": "butter_bridge",
+      "body": "I find this existence challenging",
+      "created_at": 1594329060000,
+      "votes": 100,
+      "article_img_url":
+        "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700" }
+    }
   }
 }

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -1,0 +1,24 @@
+const db = require("../db/connection");
+const { articleData } = require("../db/data/test-data");
+
+
+function fetchArticleById(id){
+    const {article_id} = id
+    if(/^\d+$/.test(article_id) === false){
+        return Promise.reject({status: 400, msg:"Bad request"})
+    }
+    
+
+    return db.query('SELECT * FROM articles WHERE article_id = $1', [article_id])
+    .then((result) => {
+      if(result.rows.length === 0){
+        return Promise.reject({status: 404, msg:"couldn't find requested article"})
+      }
+      return result.rows[0];
+    });
+
+
+
+}
+
+module.exports={fetchArticleById}


### PR DESCRIPTION
Adds GET /api/articles/:article_id, returning an article with the following properties:
author
title
article_id
body
topic
created_at
votes
article_img_url

Error handling considers:
invalid article id (e.g. article/not-a-number)
article id not found 