### PR TITLE
adds 5 GET /api/articles

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -27,6 +27,7 @@ describe('/GET incorrect path', () => {
 
 
 describe('GET/api/topics', () => {
+
     test('Responds with 200 code & with array of topics, each with: slug, description ', () => {
         return request(app)
         .get('/api/topics')
@@ -58,7 +59,7 @@ describe('/GET api', () => {
 describe('/GET api/articles:article_id', () => {
 
     test('Responds with the correct article for the given article_id', () => {
-        let article = {
+        const article = {
             article_id: 1,
             title: 'Living in the shadow of a great man',
             topic: 'mitch',
@@ -73,14 +74,6 @@ describe('/GET api/articles:article_id', () => {
         .expect(200)
         .then(({ body }) => {  
         expect(body).toEqual(article)
-        expect(typeof body.author).toBe("string");
-        expect(typeof body.title).toBe("string");
-        expect(typeof body.article_id).toBe("number");
-        expect(typeof body.body).toBe("string");
-        expect(typeof body.topic).toBe("string");
-        expect(typeof body.created_at).toBe("string");
-        expect(typeof body.votes).toBe("number");
-        expect(typeof body.article_img_url).toBe("string");
         })  
       })
 
@@ -103,4 +96,30 @@ describe('/GET api/articles:article_id', () => {
             expect(body.msg).toBe("Bad request")
         })  
     });
+});
+
+
+describe('/GET /api/articles', () => {
+
+    test('Responds with 200 code & with array of articles, each with: author,title,article_id,topic,created_at,votes,article_img_url,description ', () => {
+    return request(app)
+    .get('/api/articles')
+    .expect(200)
+    .then(({ body }) => {
+    const articles = body
+    expect(articles).toHaveLength(13)
+    expect(articles).toBeSortedBy("created_at",{descending: true,coerce:true})
+        articles.forEach((article) => {
+        expect(typeof article.author).toBe("string")
+        expect(typeof article.title).toBe("string")
+        expect(typeof article.article_id).toBe("number")
+        expect(typeof article.topic).toBe("string")
+        expect(typeof article.created_at).toBe("string")
+        expect(typeof article.votes).toBe("number")
+        expect(typeof article.article_img_url).toBe("string")
+        expect(typeof article.comment_count).toBe("number")
+        expect(article.body).toBe(undefined)
+        })
+    })  
+    }) 
 });

--- a/app.js
+++ b/app.js
@@ -2,7 +2,8 @@ const express = require("express")
 const app = express()
 const {getTopics} = require("./controllers/topics.controllers")
 const {getApi} = require("./controllers/api.controllers")
-const {getArticleById} = require("./controllers/articles.controllers")
+const {getArticleById, getArticles} = require("./controllers/articles.controllers")
+
 
 
 app.use(express.json())
@@ -12,6 +13,8 @@ app.get('/api/topics', getTopics)
 app.get('/api', getApi)
 
 app.get('/api/articles/:article_id', getArticleById)
+
+app.get('/api/articles', getArticles)
 
 
 //Error handling:

--- a/controllers/articles.controllers.js
+++ b/controllers/articles.controllers.js
@@ -1,8 +1,7 @@
 const app = require("../app")
-const {fetchArticleById} = require("../models/articles.models")
+const {fetchArticleById, fetchArticles} = require("../models/articles.models")
 
 function getArticleById(req,res,next){
-
     const id = req.params
     fetchArticleById(id)
     .then((article) => {
@@ -11,4 +10,11 @@ function getArticleById(req,res,next){
     .catch(next)
 }   
 
-module.exports={getArticleById}
+function getArticles(req,res,next){
+    fetchArticles().then((articles) => {
+    res.status(200).send(articles)
+    })
+    .catch(next)
+}
+
+module.exports={getArticleById, getArticles}

--- a/endpoints.json
+++ b/endpoints.json
@@ -39,5 +39,33 @@
       "article_img_url":
         "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700" }
     }
+  },
+  "GET /api/articles/": {
+    "description": "retrieves a list of all articles",
+    "queries": [],
+    "exampleResponse": [
+      {
+        "author": "icellusedkars",
+        "title": "Eight pug gifs that remind me of mitch",
+        "article_id": 3,
+        "topic": "mitch",
+        "created_at": "2020-11-03T09:12:00.000Z",
+        "votes": 0,
+        "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
+        "comment_count": 2
+      },
+      {
+        "author": "icellusedkars",
+        "title": "Z",
+        "article_id": 7,
+        "topic": "mitch",
+        "created_at": "2020-01-07T14:08:00.000Z",
+        "votes": 0,
+        "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
+        "comment_count": 0
+      }
+    ]
   }
+
+
 }

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -7,7 +7,6 @@ function fetchArticleById(id){
     if(/^\d+$/.test(article_id) === false){
         return Promise.reject({status: 400, msg:"Bad request"})
     }
-    
 
     return db.query('SELECT * FROM articles WHERE article_id = $1', [article_id])
     .then((result) => {
@@ -16,9 +15,25 @@ function fetchArticleById(id){
       }
       return result.rows[0];
     });
+}
 
 
+function fetchArticles(){
+
+
+    /*
+    SELECT articles.author, articles.title, articles.article_id, articles.topic, articles.created_at, articles.votes, articles.article_img_url, COUNT (comments.comment_id)::INT AS comment_count FROM articles 
+  LEFT JOIN comments ON articles.article_id = comments.article_id GROUP BY articles.article_id;
+  ORDER BY ${sort_by} ${order}
+    */
+
+  let sqlQueryString = 'SELECT articles.author, articles.title, articles.article_id, articles.topic, articles.created_at, articles.votes, articles.article_img_url, COUNT (comments.comment_id)::INT AS comment_count FROM articles LEFT JOIN comments ON articles.article_id = comments.article_id GROUP BY articles.article_id  ORDER BY articles.created_at DESC'
+
+  return db.query(sqlQueryString, [])
+    .then((result) => {
+      return result.rows;
+    });
 
 }
 
-module.exports={fetchArticleById}
+module.exports={fetchArticleById, fetchArticles}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "husky": "^8.0.2",
         "jest": "^27.5.1",
         "jest-extended": "^2.0.0",
+        "jest-sorted": "^1.0.15",
         "pg-format": "^1.0.4",
         "supertest": "^6.3.4"
       }
@@ -3252,6 +3253,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/jest-sorted": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/jest-sorted/-/jest-sorted-1.0.15.tgz",
+      "integrity": "sha512-bb5HzfyUqv22ToD63KRACZiwHVRVVj6/bl53VOODNQSzmTwKuTM0zYI73aByYulYVkugPmgGBXUTY8YLJYotKw==",
+      "dev": true
     },
     "node_modules/jest-util": {
       "version": "27.5.1",
@@ -7567,6 +7574,12 @@
           }
         }
       }
+    },
+    "jest-sorted": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/jest-sorted/-/jest-sorted-1.0.15.tgz",
+      "integrity": "sha512-bb5HzfyUqv22ToD63KRACZiwHVRVVj6/bl53VOODNQSzmTwKuTM0zYI73aByYulYVkugPmgGBXUTY8YLJYotKw==",
+      "dev": true
     },
     "jest-util": {
       "version": "27.5.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "husky": "^8.0.2",
     "jest": "^27.5.1",
     "jest-extended": "^2.0.0",
+    "jest-sorted": "^1.0.15",
     "pg-format": "^1.0.4",
     "supertest": "^6.3.4"
   },
@@ -34,7 +35,7 @@
   },
   "jest": {
     "setupFilesAfterEnv": [
-      "jest-extended/all"
+      "jest-extended/all","jest-sorted"
     ]
   }
 }


### PR DESCRIPTION
Adds a GET endpoint for /api/articles, returning an array of articles, each containing:
author
title
article id number
topic
created date/time
number of votes
image URL
comment count (the total number of comments associated with this article)

The array that is returned will be sorted by created date/time, in descending order