### PR TITLE
adds 6-GET-comments-by-article-id

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
 # Northcoders News API
 
+Summary:
+
+This probject is a backend API for a social media news and comment service. Users are able to read and post articles and comments, and upvote their favourites.
+
+
+Setup:
+
 In order to connect to the two local databases, you will need to add a .env.test and a .env.development file to your repo, each containing the relevant access credentials (format given in the .env-example file). Make sure to .gitignore these files to keep the credentials safe.
+
+
+Endpoints:
+
+You will find a list of available endpoints and their descriptions example uses in the endpoints.json file, which can also be accessed using GET: /api

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -20,13 +20,13 @@ describe('/GET incorrect path', () => {
         .get('/api/notTopics')
         .expect(404)
         .then(({ body }) => {
-          expect(body.msg).toBe("not found")
+          expect(body.msg).toBe("Not found")
         })  
       })
 });
 
 
-describe('GET/api/topics', () => {
+describe('GET /api/topics', () => {
 
     test('Responds with 200 code & with array of topics, each with: slug, description ', () => {
         return request(app)
@@ -83,7 +83,7 @@ describe('/GET api/articles:article_id', () => {
         .get('/api/articles/999999')
         .expect(404)
         .then(({ body }) => {  
-            expect(body.msg).toBe("couldn't find requested article")
+            expect(body.msg).toBe("Couldn't find requested article")
         })  
     });
 
@@ -101,7 +101,7 @@ describe('/GET api/articles:article_id', () => {
 
 describe('/GET /api/articles', () => {
 
-    test('Responds with 200 code & with array of articles, each with: author,title,article_id,topic,created_at,votes,article_img_url,description ', () => {
+    test('Responds with 200 & with array of articles', () => {
     return request(app)
     .get('/api/articles')
     .expect(200)
@@ -122,4 +122,69 @@ describe('/GET /api/articles', () => {
         })
     })  
     }) 
+});
+
+
+describe('GET /api/articles/:article_id/comments', () => {
+
+  test('Responds with 200 and array of comments (for a valid article ID & where comments exist)', () => {
+    return request(app)
+    .get('/api/articles/1/comments')
+    .expect(200)
+    .then(({ body }) => {
+        const comments = body
+        expect(comments).toHaveLength(11)
+        comments.forEach((comment) => {
+            expect(typeof comment.comment_id).toBe("number")
+            expect(typeof comment.votes).toBe("number")
+            expect(typeof comment.created_at).toBe("string")
+            expect(typeof comment.author).toBe("string")
+            expect(typeof comment.body).toBe("string")
+            expect(typeof comment.article_id).toBe("number")
+        })
+    })  
+  });
+
+  test('Responds with the list of comments sorted by date desc.', () => {
+    return request(app)
+    .get('/api/articles/1/comments')
+    .expect(200)
+    .then(({ body }) => {
+        const comments = body
+        expect(comments).toBeSortedBy("created_at",{descending: true})
+    })  
+  });
+
+
+  test('Responds with 200 and empty array for a valid article_id which has no comments associated', () => {
+  return request(app)
+  .get('/api/articles/4/comments')
+  .expect(200)
+  .then(({ body }) => {  
+  expect(body).toEqual([])
+  })  
+  });
+
+
+  test('Responds with 404 when article_id is valid but non-existent', () => {
+    return request(app)
+    .get('/api/articles/99999/comments')
+    .expect(404)
+    .then(({ body }) => {  
+    expect(body.msg).toBe("Article ID not found")
+    })  
+   });
+
+
+   test('Responds with 400 Invalid article ID when article_id is not of a valid type', () => {
+    return request(app)
+    .get('/api/articles/not-an-id-number/comments')
+    .expect(400)
+    .then(({ body }) => {  
+    expect(body.msg).toBe("Invalid article ID")
+    })  
+   });
+
+
+
 });

--- a/app.js
+++ b/app.js
@@ -3,10 +3,13 @@ const app = express()
 const {getTopics} = require("./controllers/topics.controllers")
 const {getApi} = require("./controllers/api.controllers")
 const {getArticleById, getArticles} = require("./controllers/articles.controllers")
+const {getCommentsByArticleId} = require("./controllers/comments.controllers")
 
 
 
 app.use(express.json())
+
+app.get('/api/articles/:article_id/comments',getCommentsByArticleId)
 
 app.get('/api/topics', getTopics)
 
@@ -17,17 +20,17 @@ app.get('/api/articles/:article_id', getArticleById)
 app.get('/api/articles', getArticles)
 
 
+
+
 //Error handling:
 app.get('*',(req,res) => {
-    res.status(404).send({msg : "not found"})
-
+    res.status(404).send({msg : "Not found"})
 })
 
 app.use((err, req, res, next) => {
     res.status(err.status).send({msg : err.msg})
     next(err)
 })
-
 
 app.use((err, req, res, next) => {
     res.status(500).send({msg : "internal server error"})

--- a/controllers/articles.controllers.js
+++ b/controllers/articles.controllers.js
@@ -3,6 +3,7 @@ const {fetchArticleById, fetchArticles} = require("../models/articles.models")
 
 function getArticleById(req,res,next){
     const id = req.params
+
     fetchArticleById(id)
     .then((article) => {
         res.status(200).send(article)

--- a/controllers/comments.controllers.js
+++ b/controllers/comments.controllers.js
@@ -1,0 +1,17 @@
+const app = require("../app")
+const {fetchCommentsByArticleId} = require("../models/comments.models")
+const {checkArticleExists} = require("../models/articles.models")
+
+function getCommentsByArticleId(req,res,next){
+    const {article_id} = req.params
+
+
+    Promise.all([fetchCommentsByArticleId(article_id),checkArticleExists(article_id)])
+    .then(([comments]) => {
+        res.status(200).send(comments)
+    })
+    .catch(next)
+}
+
+
+module.exports = {getCommentsByArticleId}

--- a/endpoints.json
+++ b/endpoints.json
@@ -65,7 +65,32 @@
         "comment_count": 0
       }
     ]
+  },
+  "GET /api/articles/:article:id/comments": {
+    "description": "serves an array of comments associated with a given article_id",
+    "queries": [],
+    "exampleResponse": {
+    "comments":
+      [
+        {
+          "comment_id": 5,
+          "body": "I hate streaming noses",
+          "article_id": 1,
+          "author": "icellusedkars",
+          "votes": 0,
+          "created_at": "2020-11-03T21:00:00.000Z"
+        },
+        {
+          "comment_id": 2,
+          "body": "The beautiful thing about treasure is that it exists. Got to find out what kind of sheets these are; not cotton, not rayon, silky",
+          "article_id": 1,
+          "author": "butter_bridge",
+          "votes": 14,
+          "created_at": "2020-10-31T03:03:00.000Z"
+        }]
+    }
   }
+  
 
 
 }

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -11,21 +11,32 @@ function fetchArticleById(id){
     return db.query('SELECT * FROM articles WHERE article_id = $1', [article_id])
     .then((result) => {
       if(result.rows.length === 0){
-        return Promise.reject({status: 404, msg:"couldn't find requested article"})
+        return Promise.reject({status: 404, msg:"Couldn't find requested article"})
       }
       return result.rows[0];
     });
 }
 
 
+
+function checkArticleExists(article_id){
+
+  if(/^\d+$/.test(article_id) === false){
+    return Promise.reject({status: 400, msg:"Invalid article ID"})
+}
+
+  return db.query('SELECT * FROM articles WHERE article_id = $1', [article_id])
+  .then((result) => {
+    if(result.rows.length === 0){
+      return Promise.reject({status: 404, msg: "Article ID not found"})
+    }
+  })
+}
+
+
+
+
 function fetchArticles(){
-
-
-    /*
-    SELECT articles.author, articles.title, articles.article_id, articles.topic, articles.created_at, articles.votes, articles.article_img_url, COUNT (comments.comment_id)::INT AS comment_count FROM articles 
-  LEFT JOIN comments ON articles.article_id = comments.article_id GROUP BY articles.article_id;
-  ORDER BY ${sort_by} ${order}
-    */
 
   let sqlQueryString = 'SELECT articles.author, articles.title, articles.article_id, articles.topic, articles.created_at, articles.votes, articles.article_img_url, COUNT (comments.comment_id)::INT AS comment_count FROM articles LEFT JOIN comments ON articles.article_id = comments.article_id GROUP BY articles.article_id  ORDER BY articles.created_at DESC'
 
@@ -36,4 +47,5 @@ function fetchArticles(){
 
 }
 
-module.exports={fetchArticleById, fetchArticles}
+
+module.exports={fetchArticleById, fetchArticles, checkArticleExists}

--- a/models/comments.models.js
+++ b/models/comments.models.js
@@ -1,0 +1,16 @@
+const db = require("../db/connection")
+
+
+function fetchCommentsByArticleId(article_id){
+
+    let sqlQueryString = 'SELECT * FROM comments WHERE article_id = $1 ORDER BY created_at DESC'
+
+    return db.query(sqlQueryString, [article_id])
+    .then((result) => {
+    return result.rows;
+    });
+}
+
+
+module.exports = {fetchCommentsByArticleId}
+


### PR DESCRIPTION
Adds a GET endpoint of: /api/articles/:article_id/comments, which will return an array of comments with the following properties:
comment id
votes
created at
author
body
article id

The default sort order for the array will be created at, descending (i.e. newest comments first)

Error handling has considered:
Invalid article ID
Valid but non-existent article ID
No comments found for valid and existing article ID