### PR TITLE
adds 11-get-articles-by-topic

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -195,6 +195,62 @@ describe('/api/articles', () => {
         })
     })  
     }) 
+
+    test('GET 200: (Filter) Responds with 200 & array of articles filtered by topic', () => {
+      return request(app)
+      .get('/api/articles?topic=mitch')
+      .expect(200)
+      .then(({ body }) => {
+      const articles = body
+      expect(articles).toHaveLength(12)
+      expect(articles).toBeSortedBy("created_at",{descending: true,coerce:true})
+          articles.forEach((article) => {
+          expect(typeof article.author).toBe("string")
+          expect(typeof article.title).toBe("string")
+          expect(typeof article.article_id).toBe("number")
+          expect(typeof article.created_at).toBe("string")
+          expect(typeof article.votes).toBe("number")
+          expect(typeof article.article_img_url).toBe("string")
+          expect(typeof article.comment_count).toBe("number")
+          expect(article.body).toBe(undefined)
+          expect(article.topic).toEqual("mitch")
+          })
+      })  
+      }) 
+
+      test('GET 200: (Filter) Responds with 200 & ignores invalid filter crtieria, returns array of all articles', () => {
+        return request(app)
+        .get('/api/articles?notatopic=mitch')
+        .expect(200)
+        .then(({ body }) => {
+        const articles = body
+        expect(articles).toHaveLength(13)
+        expect(articles).toBeSortedBy("created_at",{descending: true,coerce:true})
+            articles.forEach((article) => {
+            expect(typeof article.author).toBe("string")
+            expect(typeof article.title).toBe("string")
+            expect(typeof article.article_id).toBe("number")
+            expect(typeof article.topic).toBe("string")
+            expect(typeof article.created_at).toBe("string")
+            expect(typeof article.votes).toBe("number")
+            expect(typeof article.article_img_url).toBe("string")
+            expect(typeof article.comment_count).toBe("number")
+            expect(article.body).toBe(undefined)
+            })
+        })  
+        }) 
+
+
+    test('GET 404: (Filter) Responds with not found when filtering by topic that doesnt exist', () => {
+      return request(app)
+      .get('/api/articles?topic=notatopic')
+      .expect(404)
+      .then(({ body }) => {
+      expect(body.msg).toBe("Not found")
+      })  
+      }) 
+
+
 });
 
 
@@ -323,7 +379,7 @@ describe('/api/articles/:article_id/comments', () => {
     })
    });
 
-   test("POST: 400 responds with error message when given a non-existent username", () => {
+   test("POST 400: responds with error message when given a non-existent username", () => {
     let commentToAdd = { 
       username: "notausername",
       body: "Foo bar" 
@@ -384,6 +440,7 @@ describe('/api/users', () => {
     .expect(200)
     .then(({body}) => {
       const {users} = body
+      expect(users.length).not.toBe(0)
       users.forEach((user) => {
         expect(typeof user.username).toBe("string")
         expect(typeof user.name).toBe("string")

--- a/controllers/articles.controllers.js
+++ b/controllers/articles.controllers.js
@@ -12,7 +12,8 @@ function getArticleById(req,res,next){
 }   
 
 function getArticles(req,res,next){
-    fetchArticles().then((articles) => {
+    const {topic} = req.query
+    fetchArticles(topic).then((articles) => {
     res.status(200).send(articles)
     })
     .catch(next)
@@ -22,7 +23,6 @@ function getArticles(req,res,next){
 function patchArticle(req,res,next){
     const {article_id} = req.params
     const {inc_votes} = req.body
-
 
     checkArticleExists(article_id)
     .then(

--- a/endpoints.json
+++ b/endpoints.json
@@ -42,7 +42,7 @@
   },
   "GET /api/articles/": {
     "description": "retrieves a list of all articles",
-    "queries": [],
+    "queries": ["topic"],
     "exampleResponse": [
       {
         "author": "icellusedkars",

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -33,16 +33,31 @@ function checkArticleExists(article_id){
 }
 
 
-function fetchArticles(){
 
-  let sqlQueryString = 'SELECT articles.author, articles.title, articles.article_id, articles.topic, articles.created_at, articles.votes, articles.article_img_url, COUNT (comments.comment_id)::INT AS comment_count FROM articles LEFT JOIN comments ON articles.article_id = comments.article_id GROUP BY articles.article_id  ORDER BY articles.created_at DESC'
+function fetchArticles(topic){
+  const queryVals = []
 
-  return db.query(sqlQueryString, [])
+  let sqlQueryString = 'SELECT articles.author, articles.title, articles.article_id, articles.topic, articles.created_at, articles.votes, articles.article_img_url, COUNT (comments.comment_id)::INT AS comment_count FROM articles LEFT JOIN comments ON articles.article_id = comments.article_id '
+
+  if(topic){
+    sqlQueryString+='WHERE topic = $1 '
+    queryVals.push(topic)
+  }
+  
+  sqlQueryString+='GROUP BY articles.article_id ORDER BY articles.created_at DESC'
+
+
+  return db.query(sqlQueryString, queryVals)
     .then((result) => {
+      if(result.rows.length===0){
+        return Promise.reject({status: 404, msg:"Not found"})
+      }
       return result.rows;
     });
 
 }
+
+
 
 function updateArticle(article_id,newVoteTotal){
 

--- a/models/topics.models.js
+++ b/models/topics.models.js
@@ -9,5 +9,4 @@ function fetchTopics(){
 
 
 
-
 module.exports = {fetchTopics}


### PR DESCRIPTION
Adds a 'topic' query filter to /api/articles. If no topic filter is provided then all articles will be returned. 

Error handling considered:
Non-existent topic name
Invalid filter criteria