### PR TITLE
adds 12-get-article-comment-count

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -73,10 +73,29 @@ describe('/api/articles:article_id', () => {
         .get('/api/articles/1')
         .expect(200)
         .then(({ body }) => {  
-        expect(body).toEqual(article)
+        expect(body).toMatchObject(article)
         })  
       })
 
+      test('GET 200: Responds with article and the comment_count total', () => {
+        const article = {
+          article_id: 1,
+          title: expect.any(String),
+          topic: expect.any(String),
+          author: expect.any(String),
+          body: expect.any(String),
+          created_at: expect.any(String),
+          votes: expect.any(Number),
+          article_img_url: expect.any(String),
+          comment_count: expect.any(Number)
+        }
+        return request(app)
+        .get('/api/articles/1')
+        .expect(200)
+        .then(({ body }) => {  
+        expect(body).toMatchObject(article)
+        })  
+      });
 
     test('GET 404: Responds with 404 for an article_id not found', () => {
         return request(app)
@@ -87,7 +106,6 @@ describe('/api/articles:article_id', () => {
         })  
     });
 
-
     test('GET 400: Resonds with error for an invalid article_id', () => {
         return request(app)
         .get('/api/articles/not-an-id-number')
@@ -96,7 +114,6 @@ describe('/api/articles:article_id', () => {
             expect(body.msg).toBe("Bad request")
         })  
     });
-
 
     test('PATCH 200: Responds with updated article vote count when passed a valid article ID (positive number)', () => {
       let voteNumber = {inc_votes: 50}
@@ -133,7 +150,6 @@ describe('/api/articles:article_id', () => {
     })  
     });
 
-
     test('PATCH 404: Responds with not found for invalid article ID number', () => {
     let voteNumber = {inc_votes: 50}
     return request(app)
@@ -144,7 +160,6 @@ describe('/api/articles:article_id', () => {
       expect(body.msg).toBe("Article ID not found")
     })  
     });
-
 
     test('PATCH 400: Responds with bad request for invalid fields', () => {
     let voteNumber = {inc_votes: "not-a-number"}
@@ -166,8 +181,7 @@ describe('/api/articles:article_id', () => {
       .then(({ body }) => {  
       expect(body.msg).toBe("Bad request")
       })  
-      });
-
+    });
 
 });
 
@@ -460,3 +474,5 @@ describe('/api/users', () => {
 
 
 });
+
+

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -7,8 +7,9 @@ function fetchArticleById(id){
     if(/^\d+$/.test(article_id) === false){
         return Promise.reject({status: 400, msg:"Bad request"})
     }
+    let sqlString = 'SELECT articles.*, COUNT(comments.comment_id)::INT AS comment_count FROM articles    LEFT JOIN comments ON articles.article_id = comments.article_id WHERE articles.article_id = $1 GROUP BY articles.article_id ORDER BY created_at DESC'
 
-    return db.query('SELECT * FROM articles WHERE article_id = $1', [article_id])
+    return db.query(sqlString, [article_id])
     .then((result) => {
       if(result.rows.length === 0){
         return Promise.reject({status: 404, msg:"Couldn't find requested article"})


### PR DESCRIPTION
Adds a comment count property for /api/articles/:article_id which will return a count of all comments associated with that article