### PR TITLE
adds 15 sort queries for GET /api/article

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -236,13 +236,69 @@ describe('/api/articles', () => {
       }) 
 
     test('GET 404: (Filter) Responds with not found when filtering by topic that doesnt exist', () => {
-      return request(app)
-      .get('/api/articles?topic=notatopic')
-      .expect(404)
-      .then(({ body }) => {
-      expect(body.msg).toBe("Not found")
-      })  
+        return request(app)
+        .get('/api/articles?topic=notatopic')
+        .expect(404)
+        .then(({ body }) => {
+        expect(body.msg).toBe("Not found")
+        })  
       }) 
+
+    test('GET 200: (Sort) Responds with 200 & data sorted by given criteria (returns array of articles)', () => {
+        return request(app)
+        .get('/api/articles?sort_by=article_id&order=asc')
+        .expect(200)
+        .then(({ body }) => {
+        const articles = body
+        expect(articles.length).not.toBe(0)
+        expect(articles).toBeSortedBy("article_id",{coerce:true})
+        })  
+    }) 
+
+    test('GET 200: (Sort) Responds with 200 & default sort order if not specified (returns array of articles)', () => {
+      return request(app)
+      .get('/api/articles?sort_by=article_id')
+      .expect(200)
+      .then(({ body }) => {
+      const articles = body
+      expect(articles.length).not.toBe(0)
+      expect(articles).toBeSortedBy("article_id",{descending:true,coerce:true})
+      })  
+    }) 
+
+    test('GET 200: (Sort & Filter) Responds with 200 & array of sorted articles when filtered by topic)', () => {
+      return request(app)
+      .get('/api/articles?topic=mitch&sort_by=article_id&order=asc')
+      .expect(200)
+      .then(({ body }) => {
+      const articles = body
+      expect(articles).toHaveLength(12)
+      articles.forEach((article) => {
+        expect(article.topic).toEqual("mitch")
+      })
+      expect(articles).toBeSortedBy("article_id",{coerce:true})
+      })  
+    }) 
+
+    test('GET 400: (Sort) Responds with 400/bad request if sort criteria is invalid', () => {
+    return request(app)
+    .get('/api/articles?sort_by=not-a-sort-column')
+    .expect(400)
+    .then(({ body }) => {
+      expect(body.msg).toBe("Bad request")
+    })  
+    }) 
+
+    test('GET 400: (Sort) Responds with 400/bad request if sort order is invalid', () => {
+    return request(app)
+    .get('/api/articles?sort_by=article_id&order=not-a-sort-order')
+    .expect(400)
+    .then(({ body }) => {
+      expect(body.msg).toBe("Bad request")
+    })  
+    }) 
+
+
 
 });
 

--- a/controllers/articles.controllers.js
+++ b/controllers/articles.controllers.js
@@ -12,11 +12,13 @@ function getArticleById(req,res,next){
 }   
 
 function getArticles(req,res,next){
-    const {topic} = req.query
-    fetchArticles(topic).then((articles) => {
+    const {topic,sort_by,order} = req.query
+    fetchArticles(topic,sort_by,order).then((articles) => {
     res.status(200).send(articles)
     })
-    .catch(next)
+    .catch((err) => {
+        next(err)
+    })
 }
 
 

--- a/endpoints.json
+++ b/endpoints.json
@@ -42,7 +42,7 @@
   },
   "GET /api/articles/": {
     "description": "retrieves a list of all articles",
-    "queries": ["topic"],
+    "queries": ["topic","sort_by","order"],
     "exampleResponse": [
       {
         "author": "icellusedkars",

--- a/errors/index.js
+++ b/errors/index.js
@@ -1,8 +1,9 @@
 const app = require("../app")
 
+const psqlErrCodes = ['23503','22P02','23502','42703','42601']
 
 exports.handlePsqlErrors = ((err, req, res, next) => {
-    if(err.code==='23503' || err.code==='22P02' || err.code==='23502'){
+    if(psqlErrCodes.includes(err.code)){
         res.status(400).send({msg: "Bad request"})
     }
     res.status(err.status).send({msg : err.msg})

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -29,8 +29,10 @@ function checkArticleExists(article_id){
 
 
 
-function fetchArticles(topic){
+function fetchArticles(topic,sort_by = "created_at",order = "desc"){
   const queryVals = []
+  const validQuery = ["article_id","title","topic","author","created_at","votes","img_url"]
+
 
   let sqlQueryString = 'SELECT articles.author, articles.title, articles.article_id, articles.topic, articles.created_at, articles.votes, articles.article_img_url, COUNT (comments.comment_id)::INT AS comment_count FROM articles LEFT JOIN comments ON articles.article_id = comments.article_id '
 
@@ -39,7 +41,7 @@ function fetchArticles(topic){
     queryVals.push(topic)
   }
   
-  sqlQueryString+='GROUP BY articles.article_id ORDER BY articles.created_at DESC'
+  sqlQueryString+=`GROUP BY articles.article_id ORDER BY articles.${sort_by} ${order}`
 
 
   return db.query(sqlQueryString, queryVals)


### PR DESCRIPTION
Added 'sort by' and 'order' queries for GET /api/articles which will sort by the column specified, in the order specified (defaulting to 'created at' descending). 

Error handling considered:
Invalid sort criteria
Invalid order criteria